### PR TITLE
Add GitHub Action to extract references from issues

### DIFF
--- a/.github/workflows/issue-reference.yml
+++ b/.github/workflows/issue-reference.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v2
     # Install Manubot via conda
     - name: Install conda environment
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: manubot
         environment-file: environment.yml

--- a/.github/workflows/issue-reference.yml
+++ b/.github/workflows/issue-reference.yml
@@ -1,0 +1,60 @@
+# A workflow that runs on issues in the repository.
+# If an issue has the label 'reference', use Manubot to extract the citation
+# information from the reference provided in the issue title and post the
+# citation as a comment.
+# Titles must be a valid identifier Manubot can recognize as described in
+# https://github.com/manubot/rootstock/blob/master/USAGE.md#citations
+#
+# See https://github.community/t/can-we-greet-with-message-on-every-new-issue-created-opened-not-just-the-first-one/18082
+# https://github.com/marketplace/actions/create-or-update-comment
+# https://github.community/t/how-to-access-the-event-that-triggered-a-workflow/17205
+# https://github.community/t/set-output-truncates-multiline-strings/16852/3
+# https://github.community/t/do-something-if-a-particular-label-is-set/17149
+name: Extract issue reference
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  reference:
+    # Conditionally run job if the issue has the label reference
+    if: contains(github.event.issue.labels.*.name, 'reference')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    # Install Manubot via conda
+    - name: Install conda environment
+      uses: goanpeca/setup-miniconda@v1
+      with:
+        activate-environment: manubot
+        environment-file: environment.yml
+        auto-activate-base: false
+        miniconda-version: 'latest'
+    # Consider better error handling at this step because the Manubot call can fail
+    # if the reference is not a valid identifier
+    # The current behavior is that no comment will be posted, which is an
+    # acceptable failure mode
+    - name: Prepare comment body
+      id: prepare-comment
+      shell: bash --login {0}
+      run: |
+        id=${{ github.event.issue.title }}
+        body=$(manubot cite --render --format=markdown --csl=style.csl $id)
+        body="${body//$'\n'/'%0A'}"
+        body="${body//$'\r'/'%0D'}"
+        echo ::set-output name=body::$body
+    - name: Post comment to issue
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{ github.event.issue.number }}
+        body: |
+          Reference extracted for ${{ github.event.issue.title }}:
+
+          ${{ steps.prepare-comment.outputs.body }}
+
+          copy/paste as
+          ```
+          ${{ steps.prepare-comment.outputs.body }}
+          ```

--- a/environment.yml
+++ b/environment.yml
@@ -2,20 +2,19 @@ name: manubot
 channels:
   - conda-forge
 dependencies:
-  - jinja2=2.10
-  - jsonschema=3.0.1
-  - pandas=0.24.2
+  - jinja2=2.11.2
+  - jsonschema=3.2.0
   - pandoc=2.7.2
-  - pip=19.1
-  - python=3.6.7
-  - pyyaml=5.1
-  - requests=2.22.0
+  - panflute=1.12.5
+  - pip=20.2
+  - python=3.7.8
+  - pyyaml=5.3
+  - requests=2.24.0
   - pip:
     - errorhandler==2.0.1
-    - git+https://github.com/manubot/manubot@009184667f3aa8ac2b362aa7e3991ae4951cdde6
-    - isbnlib==3.9.8
-    - jsonref==0.2
+    - git+https://github.com/manubot/manubot@432327565de40bbde49b88caaa9f7ab077961413
+    - isbnlib==3.10.3
     - packaging==19.0
-    - pybase62==0.4.0
+    - pybase62==0.4.3
     - ratelimiter==1.2.0.post0
-    - requests-cache==0.5.0
+    - requests-cache==0.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,21 @@
+name: manubot
+channels:
+  - conda-forge
+dependencies:
+  - jinja2=2.10
+  - jsonschema=3.0.1
+  - pandas=0.24.2
+  - pandoc=2.7.2
+  - pip=19.1
+  - python=3.6.7
+  - pyyaml=5.1
+  - requests=2.22.0
+  - pip:
+    - errorhandler==2.0.1
+    - git+https://github.com/manubot/manubot@009184667f3aa8ac2b362aa7e3991ae4951cdde6
+    - isbnlib==3.9.8
+    - jsonref==0.2
+    - packaging==19.0
+    - pybase62==0.4.0
+    - ratelimiter==1.2.0.post0
+    - requests-cache==0.5.0

--- a/style.csl
+++ b/style.csl
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
+  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Manubot</title>
+    <id>http://www.zotero.org/styles/manubot</id>
+    <link href="http://www.zotero.org/styles/manubot" rel="self"/>
+    <link href="https://github.com/manubot/rootstock" rel="documentation"/>
+    <author>
+      <name>Daniel Himmelstein</name>
+      <email>daniel.himmelstein@gmail.com</email>
+    </author>
+    <author>
+      <name>Anthony Gitter</name>
+    </author>    
+    <updated>2020-10-29T5:19:23+00:00</updated>
+    <rights license="https://creativecommons.org/publicdomain/zero/1.0/legalcode">This work is dedicated to the public domain via CC0 1.0</rights>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name initialize="false" initialize-with="" et-al-min="12" et-al-use-first="10" et-al-use-last="true"/>
+      <label form="long" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <text macro="venue"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="venue">
+    <choose>
+      <if match="any" variable="container-title">
+        <text variable="container-title"/>
+      </if>
+      <else-if match="any" variable="container-title-short">
+        <text variable="container-title-short"/>
+      </else-if>
+      <else-if match="any" variable="publisher">
+        <text variable="publisher"/>
+      </else-if>
+      <else-if match="any" variable="collection-title">
+        <text variable="collection-title"/>
+      </else-if>
+    </choose>
+  </macro>
+  <citation>
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="[" suffix="]" delimiter=",">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" second-field-align="flush">
+    <layout>
+      <group delimiter=" ">
+        <group>
+          <text variable="title" font-weight="bold"/>
+        </group>
+        <group display="block">
+          <text macro="author"/>
+        </group>
+        <group delimiter=", ">
+          <text macro="venue" font-style="italic"/>
+          <date variable="issued">
+            <date-part name="month" form="long" suffix=" "/>
+            <date-part name="year"/>
+          </date>
+          <text variable="URL"/>
+        </group>
+        <group display="block" delimiter=" · ">
+          <text variable="DOI" text-case="lowercase" prefix="DOI: "/>
+          <text variable="PMID" prefix="PMID: "/>
+          <text variable="PMCID" prefix="PMCID: "/>
+          <text variable="ISBN" prefix="ISBN: "/>
+        </group>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automatically comment in an issue when the issue title is a manuscript identifier and the issue is labeled with `reference`.

More information in https://github.com/yangkky/Machine-learning-for-proteins/issues/16#issuecomment-719028483

The `environment.yml` and `style.csl` files are derived from the versions in https://github.com/manubot/rootstock